### PR TITLE
New schema discussed by members of the E1.37-5 task group.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Parameter Metadata Language Schema, Informative",
-  "description": "The (informative) schema for the Parameter Metadata Language from Section 5 of E1.37-5. This schema is subject to change.",
+  "description": "The (informative) schema for the Parameter Metadata Language
+                  from E1.37-5, Section 5. This schema is subject to change.",
   "definitions": {
     "bitType": {
       "description": "Describes the meaning of one bit in a bit field.",
@@ -33,13 +34,15 @@
       "required": [ "type", "bits" ]
     },
     "commandType": {
-      "description": "Represents an RDM command, a collection of 'field' items, each a simple or compound type.",
+      "description": "Represents an RDM command, a collection of 'field' items,
+                      each a simple or compound type.",
       "type": "array",
       "items": { "$ref": "#/definitions/oneOfTypes" },
       "uniqueItems": true
     },
     "compoundType": {
-      "description": "Defines a compound type, a type used to combine other types. This is useful for including in lists.",
+      "description": "Defines a compound type, a type used to combine other
+                      types. This is useful for including in lists.",
       "type": "object",
       "properties": {
         "name": { "$ref": "#/definitions/nameType" },
@@ -54,7 +57,8 @@
       "required": [ "type", "subtypes" ]
     },
     "integerType": {
-      "description": "A signed or unsigned integer, can have an optional prefix, unit, and range.",
+      "description": "A signed or unsigned integer, can have an optional
+                      prefix, unit, and range.",
       "properties": {
         "name": { "$ref": "#/definitions/nameType" },
         "type": {
@@ -82,7 +86,9 @@
           "maximum": 255
         },
         "ranges": {
-          "description": "A list of possible ranges for the value. The complete range is the union of all the ranges and labels.",
+          "description": "A list of possible ranges for the value. The
+                          complete range is the union of all the ranges and
+                          labels.",
           "type": "array",
           "items": { "$ref": "#/definitions/rangeType" },
           "uniqueItems": true
@@ -133,7 +139,8 @@
       "minLength": 1
     },
     "oneOfTypes": {
-      "description": "One of any of the types. This provides a single location to keep the list.",
+      "description": "One of any of the types. This provides a single location
+                      to keep the list.",
       "oneOf": [
         { "$ref": "#/definitions/bitFieldType" },
         { "$ref": "#/definitions/compoundType" },
@@ -146,7 +153,9 @@
       ]
     },
     "subdeviceType": {
-      "description": "A subdevice type. One of the root device (e.g. value 0), the root or all subdevices or the broadcast subdevice, the root or any subdevice, or just any subdevice.",
+      "description": "A subdevice type. One of the root device (e.g. value 0),
+                      the root or all subdevices or the broadcast subdevice,
+                      the root or any subdevice, or just any subdevice.",
       "type" : "string",
       "enum": [
             "root",
@@ -156,7 +165,10 @@
           ]
     },
     "pdEnvelopeType": {
-      "description": "Contains a length/data pair for one Parameter Data item, where the length is an unsigned 8-bit value and the data has 'length' bytes. This exists to provide a schema definition for the 'envelope' of a PDL/PD pair.",
+      "description": "Contains a length/data pair for one Parameter Data item,
+                      where the length is an unsigned 8-bit value and the data
+                      has 'length' bytes. This exists to provide a schema
+                      definition for the 'envelope' of a PDL/PD pair.",
       "type": "object",
       "properties": {
         "type": { "const": "pdEnvelope" },
@@ -184,7 +196,8 @@
       "required": [ "minimum", "maximum" ]
     },
     "simpleType": {
-      "description": "Simple type that has no fields other than a name and type.",
+      "description": "Simple type that has no fields other than a name and
+                      type.",
       "type": "object",
       "properties": {
         "name": { "$ref": "#/definitions/nameType" },
@@ -194,6 +207,7 @@
             "hostname",
             "ipv4",
             "ipv6",
+            "mac",
             "uid",
             "url"
           ]

--- a/schema.json
+++ b/schema.json
@@ -1,255 +1,252 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameter Metadata Language Schema, Informative",
+  "description": "The (informative) schema for the Parameter Metadata Language from Section 5 of E1.37-5. This schema is subject to change.",
   "definitions": {
-    "bitfield": {
+    "bitType": {
+      "description": "Describes the meaning of one bit in a bit field.",
       "type": "object",
       "properties": {
+        "name": { "$ref": "#/definitions/nameType" },
         "index": {
           "type": "integer",
           "minimum": 0
-        },
-        "name": {
-          "$ref": "#/definitions/name"
         }
       },
-      "required": ["index", "name"]
+      "required": [ "name", "index" ]
     },
-    "command": {
+    "bitFieldType": {
+      "description": "A bit field, a collection of 'bit' items.",
+      "properties": {
+        "name": { "$ref": "#/definitions/nameType" },
+        "type": { "const": "bitField" },
+        "bits": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/bitType" },
+          "uniqueItems": true
+        },
+        "size": {
+          "type": "integer",
+          "multipleOf": 8
+        } 
+      },
+      "required": [ "type", "bits" ]
+    },
+    "commandType": {
+      "description": "Represents an RDM command, a collection of 'field' items, each a simple or compound type.",
+      "type": "array",
+      "items": { "$ref": "#/definitions/oneOfTypes" },
+      "uniqueItems": true
+    },
+    "compoundType": {
+      "description": "Defines a compound type, a type used to combine other types. This is useful for including in lists.",
       "type": "object",
       "properties": {
-        "fields": {
+        "name": { "$ref": "#/definitions/nameType" },
+        "type": { "const": "compound" },
+        "subtypes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/field"
+            "$ref": "#/definitions/oneOfTypes"
           }
         }
       },
-      "required": ["fields"]
+      "required": [ "type", "subtypes" ]
     },
-    "field": {
-      "type": "object",
-      "oneOf": [
-        {
-          "properties": {
-            "type": {
-              "enum": ["bitfield"]
-            },
-            "bits": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/bitfield"
-              }
-            },
-            "size": {
-              "type": "integer",
-              "multipleOf": 8
-            }
-          },
-          "required": ["bits", "type", "size"]
+    "integerType": {
+      "description": "A signed or unsigned integer, can have an optional prefix, unit, and range.",
+      "properties": {
+        "name": { "$ref": "#/definitions/nameType" },
+        "type": {
+          "enum": [
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "uint8",
+            "uint16",
+            "uint32",
+            "uint64"
+          ]
         },
-        {
-          "properties": {
-            "type": {
-              "enum": ["bool"]
-            },
-            "name": {
-              "$ref": "#/definitions/name"
-            }
-          },
-          "required": ["name", "type"]
+        "labels": {
+          "description": "A list of labels that name special values.",
+          "type": "array",
+          "items": { "$ref": "#/definitions/labeledIntegerType" },
+          "uniqueItems": true
         },
-        {
-          "properties": {
-            "type": {
-              "enum": ["int8", "int16", "int32", "int64",
-                       "uint8", "uint16", "uint32", "uint64"]
-            },
-            "name": {
-              "$ref": "#/definitions/name"
-            },
-            "labels": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/label"
-              }
-            },
-            "prefix": {
-              "type": "integer",
-              "maximum": 255,
-              "minimum": 0
-            },
-            "ranges": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/range"
-              }
-            },
-            "unit": {
-              "type": "integer",
-              "maximum": 255,
-              "minimum": 0
-            }
-          },
-          "required": ["name", "type"]
+        "prefix": {
+          "description": "The unit prefix, defined in Table A-14 of E1.20.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
         },
-        {
-          "properties": {
-            "type": {
-              "enum": ["string"]
-            },
-            "name": {
-              "$ref": "#/definitions/name"
-            },
-            "max_size": {
-              "type": "integer",
-              "minimum": 0,
-              "exclusiveMinimum": true
-            },
-            "min_size": {
-              "type": "integer",
-              "minimum": 0
-            }
-          },
-          "required": ["name", "type"]
+        "ranges": {
+          "description": "A list of possible ranges for the value. The complete range is the union of all the ranges and labels.",
+          "type": "array",
+          "items": { "$ref": "#/definitions/rangeType" },
+          "uniqueItems": true
         },
-        {
-          "properties": {
-            "type": {
-              "enum": ["ipv4"]
-            },
-            "name": {
-              "$ref": "#/definitions/name"
-            }
-          },
-          "required": ["name", "type"]
-        },
-        {
-          "properties": {
-            "type": {
-              "enum": ["mac"]
-            },
-            "name": {
-              "$ref": "#/definitions/name"
-            }
-          },
-          "required": ["name", "type"]
-        },
-        {
-          "properties": {
-            "type": {
-              "enum": ["uid"]
-            },
-            "name": {
-              "$ref": "#/definitions/name"
-            }
-          },
-          "required": ["name", "type"]
-        },
-        {
-          "properties": {
-            "type": {
-              "enum": ["group"]
-            },
-            "name": {
-              "$ref": "#/definitions/name"
-            },
-            "fields": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/field"
-              }
-            },
-            "max_size": {
-              "type": "integer",
-              "minimum": 0,
-              "exclusiveMinimum": true
-            },
-            "min_size": {
-              "type": "integer",
-              "minimum": 0
-            }
-          },
-          "required": ["name", "fields", "type"]
+        "unit": {
+          "description": "The unit type, defined in Table A-13 of E1.20.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
         }
-      ]
+      },
+      "required": [ "type" ]
     },
-    "label": {
+    "labeledIntegerType": {
+      "description": "Associates a name to an integer value.",
       "type": "object",
       "properties": {
-        "label": {
-          "minLength": 1,
-          "type": "string"
+        "name": { "$ref": "#/definitions/nameType" },
+        "value": { "type": "integer" }
+      },
+      "required": [ "value" ]
+    },
+    "listType": {
+      "description": "A list of objects all having the same type.",
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "#/definitions/nameType" },
+        "type": { "const": "list" },
+        "itemType": {
+          "$ref": "#/definitions/oneOfTypes"
         },
-        "value": {
+        "minItems": {
+          "description": "The minimum list size.",
           "type": "integer",
-          "maximum": 4294967295,
+          "minimum": 0
+        },
+        "maxItems": {
+          "description": "The maximum list size.",
+          "type": "integer",
           "minimum": 0
         }
       },
-      "required": ["label", "value"]
+      "required": [ "type", "itemType" ]
     },
-    "name": {
+    "nameType": {
+      "description": "A name is a string having a length of at least 1.",
       "type": "string",
       "minLength": 1
     },
-    "range": {
+    "oneOfTypes": {
+      "description": "One of any of the types. This provides a single location to keep the list.",
+      "oneOf": [
+        { "$ref": "#/definitions/bitFieldType" },
+        { "$ref": "#/definitions/compoundType" },
+        { "$ref": "#/definitions/integerType" },
+        { "$ref": "#/definitions/listType" },
+        { "$ref": "#/definitions/pdEnvelopeType" },
+        { "$ref": "#/definitions/simpleType" },
+        { "$ref": "#/definitions/stringType" },
+        { "$ref": "#/definitions/subdeviceType" }
+      ]
+    },
+    "subdeviceType": {
+      "description": "A subdevice type. One of the root device (e.g. value 0), the root or all subdevices or the broadcast subdevice, the root or any subdevice, or just any subdevice.",
+      "type" : "string",
+      "enum": [
+            "root",
+            "root_or_any_subdevice_or_broadcast",
+            "root_or_any_subdevice",
+            "any_subdevice"
+          ]
+    },
+    "pdEnvelopeType": {
+      "description": "Contains a length/data pair for one Parameter Data item, where the length is an unsigned 8-bit value and the data has 'length' bytes. This exists to provide a schema definition for the 'envelope' of a PDL/PD pair.",
       "type": "object",
       "properties": {
-        "lower": {
+        "type": { "const": "pdEnvelope" },
+        "length": {
+          "description": "The data length can be optionally specified.",
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [ "type" ]
+    },
+    "rangeType": {
+      "description": "Defines an inclusive range of numbers.",
+      "type": "object",
+      "properties": {
+        "minimum": {
+          "description": "The lower bound, inclusive.",
           "type": "integer"
         },
-        "upper": {
+        "maximum": {
+          "description": "The upper bound, inclusive.",
           "type": "integer"
         }
       },
-      "required": ["lower", "upper"]
+      "required": [ "minimum", "maximum" ]
+    },
+    "simpleType": {
+      "description": "Simple type that has no fields other than a name and type.",
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "#/definitions/nameType" },
+        "type": {
+          "enum": [
+            "bool",
+            "hostname",
+            "ipv4",
+            "ipv6",
+            "uid",
+            "url"
+          ]
+        }
+      },
+      "required": [ "type" ]
+    },
+    "stringType": {
+      "description": "A string having a possibly bounded size.",
+      "properties": {
+        "name": { "$ref": "#/definitions/nameType" },
+        "type": { "const": "string" },
+        "minLength": {
+          "description": "The minimum string length.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxLength": {
+          "description": "The maximum string length.",
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [ "type" ]
     }
   },
   "type": "object",
   "properties": {
-    "get_request": {
-      "$ref": "#/definitions/command"
-    },
-    "get_response": {
-      "$ref": "#/definitions/command"
-    },
-    "get_subdevice_range": {
-      "maximum": 3,
-      "minimum": 0,
-      "type": "integer"
-    },
-    "name": {
-      "minLength": 1,
-      "type": "string"
-    },
+    "name": { "$ref": "#/definitions/nameType" },
     "pid": {
-      "maximum": 65535,
+      "type": "integer",
       "minimum": 0,
-      "type": "integer"
-    },
-    "set_request": {
-      "$ref": "#/definitions/command"
-    },
-    "set_response": {
-      "$ref": "#/definitions/command"
-    },
-    "set_subdevice_range": {
-      "maximum": 3,
-      "minimum": 0,
-      "type": "integer"
+      "maximum": 65535
     },
     "version": {
-      "minimum": 0,
-      "type": "integer"
-    }
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "get_request": { "$ref": "#/definitions/commandType" },
+    "get_response": { "$ref": "#/definitions/commandType" },
+    "get_subdevice_range" : { "$ref": "#/definitions/subdeviceType" },
+    "set_request": { "$ref": "#/definitions/commandType" },
+    "set_response": { "$ref": "#/definitions/commandType" },
+    "set_subdevice_range" : { "$ref": "#/definitions/subdeviceType" }
   },
-  "required": ["name", "pid", "version"],
+  "required": [ "name", "pid", "version" ],
   "dependencies": {
-    "get_request": ["get_response", "get_subdevice_range"],
-    "get_response": ["get_request", "get_subdevice_range"],
-    "get_subdevice_range": ["get_request", "get_response"],
-    "set_request": ["set_response", "set_subdevice_range"],
-    "set_response": ["set_request", "set_subdevice_range"],
-    "set_subdevice_range": ["set_request", "set_response"]
+    "get_request": [ "get_response" ],
+    "get_response": [ "get_request" ],
+    "get_subdevice_range" : [ "get_request", "get_response" ],   
+    "set_request": [ "set_response" ],
+    "set_response": [ "set_request" ],
+    "set_subdevice_range" : [ "set_request", "set_response" ]
   }
 }


### PR DESCRIPTION
- Modified spacing for ease in readability
- Added schema "title" (which may need to have the word "informative" removed)
- Added description values
- Changed single-value enums to "const"
- Separated "bits" from "bitField"
- Created a simpleType enum for all basic types
- Alphabetized definitions
- Changed "label" to "labeledInteger"
   * changed the "label" property to "name", for consistency
- Changed "max_size" and "min_size" to "maxLength" and "minLength", for
  consistency with JSON schema naming conventions.
* Added '"uniqueItems": true' to the "bits" field of the "bitField" field type, the integer field type, the command type, and the range type
* Created the subdeviceType with an enumeration of the possible values.
* Added a "pdEnvelope" type to help deal with the proposed PACKED_PIDS parameter message
* Added a new "list" type that represents a list of any valid non-list
  field type.
* Removed the requirement of having "name" for some of the types so they can
also be used in lists.
* Suffixed all the types with "Type" so that naming is consistent. These aren't
  the words that will be used when writing a schema and they don't have to be
  the same as the constant names, eg. "uint8" or "string" or "list".
* Added a "compoundType" type so that we don't have to make a special type for
  all possibilities. For example, the list of 3-field items returned
  in SLOT_INFO. These compound types are only supported in the list type,
  "listType", because a field is only used in "commandType".
* Factored all the types into a "oneOf" so that it can be referenced from
  "compoundType", "listType", and "fieldType".
* Changed "boundedIntegerType" to "integerType" and "boundedStringType"
  to "stringType".
* Removed "name" from the "required" list of "labeledIntegerType"
  and "listType".
* Changed "upper" and "lower" in "rangeType" to "maximum" and "minimum",
  respectively, for consistency with JSON schema naming conventions.
* Added an optional "length" property to "pdEnvelope".
* Removed "fieldType" and instead made "commandType" be a collection
  of "oneOfType".